### PR TITLE
Fix typo that suppresses error messages

### DIFF
--- a/src/LibManager.cpp
+++ b/src/LibManager.cpp
@@ -293,7 +293,7 @@ namespace lib_manager {
    */
   LibInterface* LibManager::acquireLibrary(const string &libName) {
     if(libMap.find(libName) == libMap.end()) {
-#ifdef DEBUF
+#ifdef DEBUG
       fprintf(stderr, "LibManager: could not find \"%s\"\n", libName.c_str());
 #endif
       return 0;


### PR DESCRIPTION
I didn't get any error messages for missing libraries. This should fix the problem. :)

@kavonszadkowski @malter 
