### PR TITLE
Minor changes for MSVC and debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,12 @@ set(DEPRECATED_HEADERS
 	src/LibManager.h
 )
 
+if(MSVC)
+#this is needed to create the .lib file of the shared library
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
+endif(MSVC)
+
+
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
 add_library(${PROJECT_NAME}_static STATIC ${SOURCES})
 

--- a/src/LibManager.cpp
+++ b/src/LibManager.cpp
@@ -49,7 +49,7 @@ namespace lib_manager {
   static struct LibInfo stdlibInfo = { "libstdc++", "",
                                        (__GNUC__*100+__GNUC_MINOR__),"","",0};
 #else
-#  warning Unknown standard C Library!
+//#warning Unknown standard C Library!
   static struct LibInfo stdlibInfo = { "unknown stdlib", "", 0, "", "", 0 };
 #endif
 
@@ -496,7 +496,8 @@ namespace lib_manager {
         fprintf(stderr, "lib_manager - NOTIFICATION (concerning optional library):\n     %s\n",
                 errorMsg.c_str());
       } else {
-        fprintf(stderr, "lib_manager - ERROR:\n     %s\n",
+        fprintf(stderr, "lib_manager - ERROR loading %s:\n     %s\n",
+                libPath.c_str(),
                 errorMsg.c_str());
       }
     }


### PR DESCRIPTION
Hi guys.
For MSVC there is a flag which creates the lib file for a shared library (CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS).
Also I extended the output if a library could not be loaded to show the actual name of the library.
