### PR TITLE
Fix lib_manager qt5 widgets includes

### DIFF
--- a/scripts/cmake/lib_manager.cmake
+++ b/scripts/cmake/lib_manager.cmake
@@ -87,7 +87,7 @@ macro(setup_qt)
 
     # The Qt5Widgets_INCLUDES also includes the include directories for
     # dependencies QtCore and QtGui
-    include_directories(${Qt5Widgets_INCLUDES})
+    include_directories(${Qt5Widgets_INCLUDE_DIRS})
     # We need add -DQT_WIDGETS_LIB when using QtWidgets in Qt 5.
     add_definitions(${Qt5Widgets_DEFINITIONS})
 


### PR DESCRIPTION
Hi Malte,

with the qt4 style QT_INCLUDES, my mars was not able to find the path to the qt5 widgets includes. The QT_INCLUDE_DIRS does work.

Reference: https://www.kdab.com/using-cmake-with-qt-5/

`Once the package has been found, Qt 4 users would use the CMake variables ${QT_INCLUDES} to set the include directories while compiling, and ${QT_LIBRARIES} or ${QT_GUI_LIBRARIES} while linking. Users of CMake with Qt 4 may have also used the ${QT_USE_FILE} to semi-automatically include the required include directories and required defines. With the modular Qt 5 system, the variables will instead be ${Qt5Widgets_INCLUDE_DIRS}, ${Qt5Widgets_LIBRARIES}, ${Qt5Declarative_INCLUDE_DIRS}, ${Qt5Declarative_LIBRARIES} etc for each module used.`


Best,
Haider